### PR TITLE
Update sign-in spec to case insensitive

### DIFF
--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -10,7 +10,7 @@ feature 'Sign in', :devise do
   #   Then I see an invalid credentials message
   scenario 'user cannot sign in if not registered' do
     sign_in('test@example.com', 'please123')
-    expect(page).to have_content I18n.t (/#{I18n.t('devise.failure.not_found_in_database', authentication_keys: 'email')}/i)
+    expect(page).to have_content(/#{I18n.t('devise.failure.not_found_in_database', authentication_keys: 'email')}/i)
   end
 
   # Scenario: User can sign in with valid credentials
@@ -32,7 +32,7 @@ feature 'Sign in', :devise do
   scenario 'user cannot sign in with wrong email' do
     user = FactoryGirl.create(:user)
     sign_in('invalid@email.com', user.password)
-    expect(page).to have_content I18n.t (/#{I18n.t('devise.failure.not_found_in_database', authentication_keys: 'email')}/i)
+    expect(page).to have_content(/#{I18n.t('devise.failure.not_found_in_database', authentication_keys: 'email')}/i)
   end
 
   # Scenario: User cannot sign in with wrong password
@@ -43,7 +43,7 @@ feature 'Sign in', :devise do
   scenario 'user cannot sign in with wrong password' do
     user = FactoryGirl.create(:user)
     sign_in(user.email, 'invalidpass')
-    expect(page).to have_content I18n.t (/#{I18n.t('devise.failure.invalid', authentication_keys: 'email')}/i)
+    expect(page).to have_content(/#{I18n.t('devise.failure.invalid', authentication_keys: 'email')}/i)
   end
 
 end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -10,7 +10,7 @@ feature 'Sign in', :devise do
   #   Then I see an invalid credentials message
   scenario 'user cannot sign in if not registered' do
     sign_in('test@example.com', 'please123')
-    expect(page).to have_content I18n.t 'devise.failure.not_found_in_database', authentication_keys: 'email'
+    expect(page).to have_content I18n.t (/#{I18n.t('devise.failure.not_found_in_database', authentication_keys: 'email')}/i)
   end
 
   # Scenario: User can sign in with valid credentials
@@ -32,7 +32,7 @@ feature 'Sign in', :devise do
   scenario 'user cannot sign in with wrong email' do
     user = FactoryGirl.create(:user)
     sign_in('invalid@email.com', user.password)
-    expect(page).to have_content I18n.t 'devise.failure.not_found_in_database', authentication_keys: 'email'
+    expect(page).to have_content I18n.t (/#{I18n.t('devise.failure.not_found_in_database', authentication_keys: 'email')}/i)
   end
 
   # Scenario: User cannot sign in with wrong password
@@ -43,7 +43,7 @@ feature 'Sign in', :devise do
   scenario 'user cannot sign in with wrong password' do
     user = FactoryGirl.create(:user)
     sign_in(user.email, 'invalidpass')
-    expect(page).to have_content I18n.t 'devise.failure.invalid', authentication_keys: 'email'
+    expect(page).to have_content I18n.t (/#{I18n.t('devise.failure.invalid', authentication_keys: 'email')}/i)
   end
 
 end


### PR DESCRIPTION
@mendel This corrects "Invalid Email or password" type grammatically incorrect errors which don't pass the current tests. Uses corrections made by @gj for https://github.com/learn-co-curriculum/devise_lab/pull/20

Corrects issue #19 

Devise still has an open issue regarding the capitalization problem: https://github.com/plataformatec/devise/issues/4095